### PR TITLE
taking it to bgpmon-8.0-dev. This creates a ~vagrant/devel/go directo…

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ contains several BGP related tools.
 
 ## Installed tools
 
-  * BGPmon 7.4 (http://www.bgpmon.io)
+  * BGPmon 8.0-dev (http://www.bgpmon.io)
   * BGPStream 1.1.0 (https://bgpstream.caida.org)
   * OpenBMP 0.11.0-pre3 (http://www.openbmp.org)
   * Kafka 0.8.2.3 (http://kafka.apache.org)

--- a/scripts/bgpmon.sh
+++ b/scripts/bgpmon.sh
@@ -1,10 +1,26 @@
 #!/usr/bin/env bash
+#fetches the git bgpmon version, golang1.5 bin for linux/amd64, protocol buffers compiler,
+#golang protoc target compiler and sets the necessary paths for the vagrant user to use them
+BGPMON_VERSION=dev
+GO_VERSION="1.5.3"
+GO_ARCH="amd64"
 
-BGPMON_VERSION=7.4
+apt-get -y install git autoconf unzip libtool
+cd ~vagrant
+sudo -u vagrant cat <<EOF
+export PATH="$PATH:/usr/local/go/bin:$HOME/devel/go/bin"
+export GOPATH="$HOME/devel/go/"
+EOF
+>>~vagrant/.profile
+source ~vagrant/.profile
 
-apt-get -y install libxml2-dev
-
-(cd /vagrant/deps && wget --quiet -c http://www.bgpmon.io/downloads/bgpmon-$BGPMON_VERSION.tar.bz2)
-mkdir /tmp/bgpmon || exit 1
-tar -xf /vagrant/deps/bgpmon-$BGPMON_VERSION.tar.bz2 -C /tmp/bgpmon/
-(cd /tmp/bgpmon/ && ./configure --quiet && make install)
+(sudo -u vagrant mkdir -p ~vagrant/devel/go/{src,pkg,bin})
+(cd /vagrant/deps && wget https://storage.googleapis.com/golang/go${GO_VERSION}.linux-${GO_ARCH}.tar.gz && tar -C/usr/local -xzvf go${GO_VERSION}.linux-${GO_ARCH}.tar.gz)
+export PATH="$PATH:/usr/local/go/bin:/home/vagrant/devel/go/bin"
+export GOPATH="/home/vagrant/devel/go"
+(cd /vagrant/deps && git clone https://github.com/google/protobuf)
+(cd /vagrant/deps/protobuf/ && ./autogen.sh && ./configure && make && make install && ldconfig)
+(sudo -E -u vagrant /usr/local/go/bin/go get -u github.com/golang/protobuf/{proto,protoc-gen-go})
+(cd ~vagrant/devel/go/src/ && sudo -u vagrant git clone http://git.netsec.colostate.edu/bgpmon/)
+(cd ~vagrant/devel/go/src/bgpmon && sudo -u vagrant GOPATH=/home/vagrant/devel/go/ PATH="$PATH:/home/vagrant/devel/go/bin/" make)
+(rm -rf /vagrant/deps/go${GO_VERSION}.linux-${GO_ARCH}.tar.gz /vagrant/deps/protobuf)


### PR DESCRIPTION
…ry containing the bgpmon codebase.Installs golang 1.5.2, protbuf3 with the golang target, autoconf and libtool
